### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 Notifies your webmails, improvement and fix for X-notifier 3.5.23 because original author has been abandoned this version. 
 
 ## Requirement
-- Firefox 3 - 56
+- Firefox 13 - 56
+- Firefox Nightly 57 with `extensions.legacy.enabled = true` and `extensions.allow-non-mpc-extensions = true`.
 
 ## Release History
 - 3.5.25 - August 14 2017: 
-  - Fix Yahoo Login, thanks to @jeroen1956 and @Loirooriol
+  - Fix Yahoo Login, thanks to @jeroen1956
+  - Compatibility with Firefox 57, thanks to @Loirooriol
 
 - 3.5.24: 
   - fixed Gmail bugs: `isLoggedIn -> basic HTML`


### PR DESCRIPTION
 - The add-on won't work before Firefox 13 because of lack of `for...of` support
 - It works on Firefox 57 with some Nightly-only prefs.
 - I didn't participate in the Yahoo fix.